### PR TITLE
Travel Board updates: invite codes, privacy, membership handling, tests, and user search

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/PrivacyLevel.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/PrivacyLevel.java
@@ -1,5 +1,5 @@
 package ch.uzh.ifi.hase.soprafs26.constant;
 
 public enum PrivacyLevel {
-	PUBLIC, PRIVATE;
+	PUBLIC, FRIENDS, PRIVATE;
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/InvitationController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/InvitationController.java
@@ -1,5 +1,8 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -55,5 +58,20 @@ public class InvitationController {
 		invitationService.declineInvitation(invitationId, token);
 	}	
 
+	@GetMapping("/invitations")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public List<InvitationGetDTO> getPendingInvitations(@RequestHeader(value = "Authorization", required = false) String token) {
+		userService.validateToken(token);
+
+		List<Invitation> pendingInvitations = invitationService.getPendingInvitations(token);
+
+		List<InvitationGetDTO> invitationGetDTOs = new ArrayList<>();
+
+		for (Invitation invitation : pendingInvitations) {
+            invitationGetDTOs.add(DTOMapper.INSTANCE.convertEntityToInvitationGetDTO(invitation));
+        }
+		return invitationGetDTOs;
+	}
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardController.java
@@ -61,10 +61,10 @@ public class TravelBoardController {
         travelBoardService.deleteTravelBoard(boardId, token);
     }
 
-    @GetMapping("/travelboards/my")
+    @GetMapping("/travelboards")
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
-    public List<TravelBoardGetDTO> getTravelBoardsByUser(@RequestHeader(value = "Authorization", required = false) String token){
+    public List<TravelBoardGetDTO> getTravelBoardsByUser(@RequestHeader(value = "Authorization", required = false) String token, @RequestParam String user){
         userService.validateToken(token);
         List<TravelBoard> travelBoards = travelBoardService.getTravelBoardsByUser(token);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardController.java
@@ -63,6 +63,13 @@ public class TravelBoardController {
         travelBoardService.deleteTravelBoard(boardId, token);
     }
 
+    @DeleteMapping("/travelboards/{boardId}/membership")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveTravelBoard(@PathVariable Long boardId, @RequestHeader(value = "Authorization", required = false) String token) {
+        userService.validateToken(token);
+        travelBoardService.leaveTravelBoard(boardId, token);
+      }
+
     @GetMapping("/travelboards")
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
@@ -106,5 +113,6 @@ public class TravelBoardController {
 
         travelBoardService.addPlaces(boardId, token, placeInput);
     }
+
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardController.java
@@ -6,7 +6,9 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Place;
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.PlacePostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardPutDTO;
@@ -93,5 +95,16 @@ public class TravelBoardController {
         travelBoardService.joinTravelBoardByInviteCode(token, inviteCode);
 
 	}
+
+    @PostMapping("/travelboards/{boardId}/places")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseBody
+    public void addPlaceToBoard(@PathVariable Long boardId, @RequestHeader(value = "Authorization", required = false) String token, @RequestBody PlacePostDTO placePostDTO) {
+        userService.validateToken(token);
+
+        Place placeInput = DTOMapper.INSTANCE.convertPlacePostDTOtoEntity(placePostDTO);
+
+        travelBoardService.addPlaces(boardId, token, placeInput);
+    }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -124,4 +124,20 @@ public class UserController {
 		userService.updatePassword(id, userPutDTO.getPassword());
 	}
 
+	//shows matching users while typing
+	@GetMapping("/users/search")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public List<UserGetDTO> searchUsersByUsername(@RequestHeader(value = "Authorization", required = false) String token, @RequestParam String username) {
+		userService.validateToken(token);
+	  	List<User> users = userService.searchUsersByUsername(token, username);
+	  	List<UserGetDTO> userGetDTOs = new ArrayList<>();
+		
+	  	for (User user : users) {
+	    	userGetDTOs.add(DTOMapper.INSTANCE.convertEntityToUserGetDTO(user));
+	  	}
+  
+	 	return userGetDTOs;
+	}
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/InvitationRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/InvitationRepository.java
@@ -1,10 +1,14 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.constant.InviteStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Invitation;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 @Repository("invitationRepository")
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
-	
+    List<Invitation> findByReceiverAndStatus(User receiver, InviteStatus status);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PlaceRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/PlaceRepository.java
@@ -1,0 +1,10 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ch.uzh.ifi.hase.soprafs26.entity.Place;
+
+@Repository("placeRepository")
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	User findByEmail(String email);
 	User findByUsername(String username);
 	User findByToken(String token); // for token validation during authorization
+	List<User> findByUsernameContainingIgnoreCase(String username);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/InvitationGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/InvitationGetDTO.java
@@ -14,6 +14,9 @@ public class InvitationGetDTO {
 
     private InviteStatus status;
     
+    private String boardName;
+    
+    private String senderUsername;
 			
 
     public Long getId() {
@@ -54,6 +57,22 @@ public class InvitationGetDTO {
 
     public void setStatus(InviteStatus status) {
         this.status = status;
+    }
+
+    public String getBoardName() {
+        return boardName;
+    }
+    
+    public void setBoardName(String boardName) {
+        this.boardName = boardName;
+    }
+    
+    public String getSenderUsername() {
+        return senderUsername;
+    }
+    
+    public void setSenderUsername(String senderUsername) {
+        this.senderUsername = senderUsername;
     }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PlacePostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/PlacePostDTO.java
@@ -1,34 +1,11 @@
-package ch.uzh.ifi.hase.soprafs26.entity;
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
 
-import jakarta.persistence.*;
+public class PlacePostDTO {
 
-import java.io.Serializable;
-		
-
-@Entity
-@Table(name = "places")
-public class Place implements Serializable {
-    @Id
-	@GeneratedValue
-	private Long id;
-    
-    @Column(nullable = false)
     private String name;
-
-    @Column(nullable = false)
+    private String address;
     private Double latitude;
-
-    @Column(nullable = false)
     private Double longitude;
-
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;
@@ -38,6 +15,13 @@ public class Place implements Serializable {
         this.name = name;
     }
 
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
 
     public Double getLatitude() {
         return latitude;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TravelBoardPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TravelBoardPostDTO.java
@@ -14,6 +14,8 @@ public class TravelBoardPostDTO {
 
 	private LocalDate endDate;
 
+	private String inviteCode;
+
 	private PrivacyLevel privacy; 			
 
 
@@ -41,6 +43,13 @@ public class TravelBoardPostDTO {
 		this.endDate = endDate;
 	}
 
+	public String getInviteCode() {
+        return inviteCode;
+    }
+
+    public void setInviteCode(String inviteCode) {
+        this.inviteCode = inviteCode;
+    }
 
 	public PrivacyLevel getPrivacy() {
 		return privacy;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -4,9 +4,11 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Invitation;
+import ch.uzh.ifi.hase.soprafs26.entity.Place;
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.InvitationGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.PlacePostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
@@ -69,4 +71,8 @@ public interface DTOMapper {
 	@Mapping(source = "status", target = "status")
     InvitationGetDTO convertEntityToInvitationGetDTO(Invitation createdInvitation);
 
+	@Mapping(source = "name", target = "name")
+	@Mapping(source = "latitude", target = "latitude")
+	@Mapping(source = "longitude", target = "longitude")
+    Place convertPlacePostDTOtoEntity(PlacePostDTO placePostDTO);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -69,6 +69,8 @@ public interface DTOMapper {
 	@Mapping(source = "sender.id", target = "senderId")
 	@Mapping(source = "receiver.id", target = "receiverId")
 	@Mapping(source = "status", target = "status")
+	@Mapping(source = "board.name", target = "boardName")
+	@Mapping(source = "sender.username", target = "senderUsername")
     InvitationGetDTO convertEntityToInvitationGetDTO(Invitation createdInvitation);
 
 	@Mapping(source = "name", target = "name")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -47,6 +47,7 @@ public interface DTOMapper {
 	@Mapping(source = "name", target = "name")
 	@Mapping(source = "startDate", target = "startDate")
 	@Mapping(source = "endDate", target = "endDate")
+	@Mapping(source = "inviteCode", target = "inviteCode")
 	@Mapping(source = "privacy", target = "privacy")
     TravelBoard convertTravelBoardPostDTOtoEntity(TravelBoardPostDTO travelBoardPostDTO);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/InvitationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/InvitationService.java
@@ -117,4 +117,14 @@ public class InvitationService {
         invitationRepository.save(invitation);
     }
 
+    public List<Invitation> getPendingInvitations(String token) {
+        User user = userRepository.findByToken(token);
+
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found");
+        }
+
+        return invitationRepository.findByReceiverAndStatus(user, InviteStatus.PENDING);
+    }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
@@ -56,7 +56,7 @@ public class TravelBoardService {
         if (newTravelBoard.getInviteCode() == null || newTravelBoard.getInviteCode().trim().isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invite code cannot be empty");
         }
-        if (travelBoardRepository.findByInviteCode(newTravelBoard.getInviteCode()) != null) {
+        if (travelBoardRepository.findByInviteCode(newTravelBoard.getInviteCode().trim().isEmpty()) != null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Invite code already exists");
         }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import ch.uzh.ifi.hase.soprafs26.entity.Place;
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.TravelBoardRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.PlaceRepository;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -26,10 +28,12 @@ public class TravelBoardService {
 
 	private final TravelBoardRepository travelBoardRepository;
     private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
 
-	public TravelBoardService(@Qualifier("travelBoardRepository") TravelBoardRepository travelBoardRepository, UserRepository userRepository) {
+	public TravelBoardService(@Qualifier("travelBoardRepository") TravelBoardRepository travelBoardRepository, UserRepository userRepository, PlaceRepository placeRepository) {
 		this.travelBoardRepository = travelBoardRepository;
         this.userRepository = userRepository;
+        this.placeRepository = placeRepository;
 	}
 
 	public List<TravelBoard> getTravelBoards() {
@@ -142,4 +146,25 @@ public class TravelBoardService {
         board.getMembers().add(user);
         travelBoardRepository.save(board);        
     }
+
+    public void addPlaces(Long boardId, String token, Place newPlace) {
+        User user = userRepository.findByToken(token);
+        Long userId = user.getId();
+
+        TravelBoard board = travelBoardRepository.findById(boardId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Travel board not found"));
+
+        if (!board.getOwner().getId().equals(userId) && !(board.getMembers().contains(user))) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Only board members can add places");
+        }
+
+        if (newPlace.getLatitude() == null || newPlace.getLongitude() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Latitude and longitude are required");
+        }
+
+        Place savedPlace = placeRepository.save(newPlace);
+        board.getPlaces().add(savedPlace);
+        travelBoardRepository.save(board);
+
+    }   
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
@@ -103,6 +103,24 @@ public class TravelBoardService {
         travelBoardRepository.delete(board);
     }
 
+    public void leaveTravelBoard(Long boardId, String token) {
+        User user = userRepository.findByToken(token);
+
+        TravelBoard board = travelBoardRepository.findById(boardId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Travel board not found"));
+
+        if (board.getOwner().getId().equals(user.getId())) {
+          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Owner cannot leave the board with this action");
+        }
+
+        if (!board.getMembers().contains(user)) {
+          throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User is not a member of this travel board");
+        }
+
+        board.getMembers().remove(user);
+        travelBoardRepository.save(board);
+    }
+
     public List<TravelBoard> getTravelBoardsByUser(String token) {
         User user = userRepository.findByToken(token);
         Long userId = user.getId();

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TravelBoardService.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
@@ -17,7 +16,6 @@ import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 
 @Service
@@ -50,10 +48,15 @@ public class TravelBoardService {
         if (newTravelBoard.getStartDate() != null && newTravelBoard.getEndDate() != null
             && newTravelBoard.getStartDate().isAfter(newTravelBoard.getEndDate())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Start date cannot be after end date");
-            }
+        }
+        if (newTravelBoard.getInviteCode() == null || newTravelBoard.getInviteCode().trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invite code cannot be empty");
+        }
+        if (travelBoardRepository.findByInviteCode(newTravelBoard.getInviteCode()) != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Invite code already exists");
+        }
 
         newTravelBoard.setOwner(owner);
-        newTravelBoard.setInviteCode(UUID.randomUUID().toString().substring(0, 8));
         newTravelBoard.setDateCreated(LocalDate.now());
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -161,4 +161,12 @@ public class UserService {
 		}
 	}
 
+	public List<User> searchUsersByUsername(String token, String username) {
+  		if (username == null || username.trim().isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username query must not be empty");	
+		}
+
+		return userRepository.findByUsernameContainingIgnoreCase(username.trim());
+	}
+
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardControllerTest.java
@@ -1,0 +1,135 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import ch.uzh.ifi.hase.soprafs26.service.TravelBoardService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardPutDTO;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(TravelBoardController.class)
+public class TravelBoardControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private TravelBoardService travelBoardService;
+
+    @MockitoBean
+    private UserService userService;
+
+    //#119
+	@Test
+	public void renameTravelBoard_validInput_noContent() throws Exception {
+        Long boardId = 1L;
+        String token = "ABC";
+
+		TravelBoardPutDTO travelBoardPutDTO = new TravelBoardPutDTO();
+		travelBoardPutDTO.setName("Renamed Board");
+
+        Mockito.doNothing().when(userService).validateToken(token);
+		Mockito.doNothing().when(travelBoardService).renameTravelBoard(boardId, token, "Renamed Board");
+		
+		MockHttpServletRequestBuilder putRequest = put("/travelboards/{boardId}", boardId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", token)
+				.content(asJsonString(travelBoardPutDTO));
+
+		mockMvc.perform(putRequest)
+				.andExpect(status().isNoContent());
+	}
+
+    //#118
+	@Test
+	public void deleteTravelBoard_validInput_noContent() throws Exception {
+		Long boardId = 1L;
+        String token = "ABC";
+
+        Mockito.doNothing().when(userService).validateToken(token);
+        Mockito.doNothing().when(travelBoardService).deleteTravelBoard(boardId, token);
+
+		MockHttpServletRequestBuilder deleteRequest = delete("/travelboards/{boardId}", boardId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON); 
+
+		mockMvc.perform(deleteRequest)
+				.andExpect(status().isNoContent()); 
+	}
+
+    //#120
+	@Test
+    public void renameTravelBoard_notOwner_unauthorized() throws Exception {
+        Long boardId = 1L;
+        String token = "ABC";
+        
+        TravelBoardPutDTO travelBoardPutDTO = new TravelBoardPutDTO();
+        travelBoardPutDTO.setName("Hacked Name");
+        
+        Mockito.doNothing().when(userService).validateToken(token);
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized - must be owner"))
+                .when(travelBoardService)
+                .renameTravelBoard(boardId, token, "Hacked Name");
+        
+        MockHttpServletRequestBuilder putRequest = put("/travelboards/{boardId}", boardId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", token)
+                .content(asJsonString(travelBoardPutDTO));
+        
+        mockMvc.perform(putRequest)
+                .andExpect(status().isUnauthorized());
+    }
+
+    //#120
+    @Test
+    public void deleteTravelBoard_notOwner_unauthorized() throws Exception {
+        Long boardId = 1L;
+        String token = "ABC";
+
+        Mockito.doNothing().when(userService).validateToken(token);
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized - must be owner"))
+                .when(travelBoardService)
+                .deleteTravelBoard(boardId, token);
+
+        MockHttpServletRequestBuilder deleteRequest = delete("/travelboards/{boardId}", boardId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(deleteRequest)
+                .andExpect(status().isUnauthorized());
+    }
+	
+
+	/**
+	 * Helper Method to convert userPostDTO into a JSON string such that the input
+	 * can be processed
+	 * Input will look like this: {"name": "Test User", "username": "testUsername"}
+	 * 
+	 * @param object
+	 * @return string
+	 */
+	private String asJsonString(final Object object) {
+		try {
+			return new ObjectMapper().writeValueAsString(object);
+		} catch (JacksonException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+					String.format("The request body could not be created.%s", e.toString()));
+		}
+	}
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
@@ -1,0 +1,122 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.web.WebAppConfiguration;
+import ch.uzh.ifi.hase.soprafs26.constant.PrivacyLevel;
+import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.TravelBoardRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+/**
+ * Test class for the UserResource REST resource.
+ *
+ * @see TravelBoardService
+ */
+@WebAppConfiguration
+@SpringBootTest
+public class TravelboardServiceIntegrationTest {
+
+	@Qualifier("userRepository")
+	@Autowired
+	private UserRepository userRepository;
+
+    
+	@Qualifier("travelBoardRepository")
+	@Autowired
+	private TravelBoardRepository travelBoardRepository;
+
+	@Autowired
+	private TravelBoardService travelBoardService;
+
+	@BeforeEach
+	public void setup() {
+		travelBoardRepository.deleteAll();
+        userRepository.deleteAll();
+	}
+    
+    //#118
+    @Test
+    public void deleteTravelBoard_removesBoardFromDatabase() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+    
+        // simulate login token
+        user.setToken("token123");
+        userRepository.save(user);
+    
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Test Board");
+        board.setOwner(user);
+        board.setInviteCode("DEL123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+    
+        board = travelBoardRepository.save(board);
+    
+        Long boardId = board.getId();
+    
+        // delete
+        travelBoardService.deleteTravelBoard(boardId, "token123");
+    
+        // assert
+        assertTrue(travelBoardRepository.findById(boardId).isEmpty());
+    }
+
+    //#119
+    @Test
+    public void renameTravelBoard_updatesBoardNameInDatabase() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+
+        // simulate login token
+        user.setToken("token123");
+        userRepository.save(user);
+
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Old Name");
+        board.setOwner(user);
+        board.setInviteCode("REN123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+
+        board = travelBoardRepository.save(board);
+
+        Long boardId = board.getId();
+
+        // rename
+        travelBoardService.renameTravelBoard(boardId, "token123", "New Name");
+
+        // assert
+        TravelBoard updated = travelBoardRepository.findById(boardId).orElseThrow();
+
+        assertEquals("New Name", updated.getName());
+    }
+}


### PR DESCRIPTION
this Pull Request includes:
#129  Update travel board creation to accept frontend-generated invite code and new privacy value "FRIENDS" (I realised the frontend never posts the inviteCode to the backend so it, won't be saved, need to be fixed in the frontend)

#188 and #190: This commit with Places might need to be deleted, depending on how we will implement it in the end....

#233 endponit to remove the membership not delete the board, if you're member

#118, #119, #120 Tests delete and renaming Travelboard

#174, #216, searches/returns a list of users containing the given string 

#240 get pending invitations of a user (inkl. board name and sender username)