### PR TITLE
Implement friend request and friend management endpoints

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/FriendRequestStatus.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/FriendRequestStatus.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum FriendRequestStatus {
+	PENDING, ACCEPTED, DECLINED;
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/FriendRequestController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/FriendRequestController.java
@@ -1,5 +1,8 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +29,7 @@ public class FriendRequestController {
 	}
 
 
-	@PostMapping("/friendRequest")
+	@PostMapping("/friendRequests")
 	@ResponseStatus(HttpStatus.CREATED)
 	@ResponseBody
 	public FriendRequestGetDTO sendFriendRequest(@RequestBody FriendRequestPostDTO friendRequestPostDTO, @RequestHeader(value = "Authorization", required = false) String token) {
@@ -35,6 +38,40 @@ public class FriendRequestController {
 		FriendRequest createdRequest = friendRequestService.sendFriendRequest(token, friendRequestPostDTO.getReceiverId());
 
 		return DTOMapper.INSTANCE.convertEntityToFriendRequestGetDTO(createdRequest);
+	}
+
+	@GetMapping("/friendRequests")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public List<FriendRequestGetDTO> getPendingFriendRequests(@RequestHeader(value = "Authorization", required = false) String token) {
+		userService.validateToken(token);
+
+		List<FriendRequest> pendingFriendRequests = friendRequestService.getPendingFriendRequests(token);
+
+		List<FriendRequestGetDTO> friendRequestGetDTOs = new ArrayList<>();
+
+		for (FriendRequest friendRequest : pendingFriendRequests) {
+            friendRequestGetDTOs.add(DTOMapper.INSTANCE.convertEntityToFriendRequestGetDTO(friendRequest));
+        }
+		return friendRequestGetDTOs;
+	}
+
+	@PutMapping("/friendRequests/{friendRequestId}/accept")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@ResponseBody
+	public void acceptFriendRequest(@RequestHeader(value = "Authorization", required = false) String token, @PathVariable Long friendRequestId) {
+		userService.validateToken(token);
+
+		friendRequestService.acceptFriendRequest(friendRequestId, token);
+	}	
+
+	@PutMapping("/friendRequests/{friendRequestId}/decline")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@ResponseBody
+	public void declineFriendRequest(@RequestHeader(value = "Authorization", required = false) String token, @PathVariable Long friendRequestId) {
+		userService.validateToken(token);
+
+		friendRequestService.declineFriendRequest(friendRequestId, token);
 	}
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/FriendRequestController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/FriendRequestController.java
@@ -1,0 +1,41 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import ch.uzh.ifi.hase.soprafs26.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.FriendRequestGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.FriendRequestPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.FriendRequestService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+
+
+
+
+
+@RestController
+public class FriendRequestController {
+
+	private final FriendRequestService friendRequestService;
+	private final UserService userService;
+
+	FriendRequestController(FriendRequestService friendRequestService, UserService userService) {
+		this.friendRequestService = friendRequestService;
+		this.userService = userService;
+	}
+
+
+	@PostMapping("/friendRequest")
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public FriendRequestGetDTO sendFriendRequest(@RequestBody FriendRequestPostDTO friendRequestPostDTO, @RequestHeader(value = "Authorization", required = false) String token) {
+		userService.validateToken(token);
+
+		FriendRequest createdRequest = friendRequestService.sendFriendRequest(token, friendRequestPostDTO.getReceiverId());
+
+		return DTOMapper.INSTANCE.convertEntityToFriendRequestGetDTO(createdRequest);
+	}
+
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/FriendRequestController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/FriendRequestController.java
@@ -7,8 +7,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import ch.uzh.ifi.hase.soprafs26.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.FriendRequestGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.FriendRequestPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.service.FriendRequestService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
@@ -72,6 +74,29 @@ public class FriendRequestController {
 		userService.validateToken(token);
 
 		friendRequestService.declineFriendRequest(friendRequestId, token);
+	}
+
+	@GetMapping("/friends")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public List<UserGetDTO> getFriends(@RequestHeader(value = "Authorization", required = false) String token) {
+		userService.validateToken(token);
+
+		List<User> friends = friendRequestService.getFriends(token);
+
+		List<UserGetDTO> friendsDTOs = new ArrayList<>();
+
+		for (User friend : friends) {
+            friendsDTOs.add(DTOMapper.INSTANCE.convertEntityToUserGetDTO(friend));
+        }
+		return friendsDTOs;
+	}
+
+	@DeleteMapping("/friends/{friendId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void removeFriend(@RequestHeader(value = "Authorization", required = false) String token, @PathVariable Long friendId) {
+	    userService.validateToken(token);
+	    friendRequestService.removeFriend(token, friendId);
 	}
 
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/FriendRequest.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/FriendRequest.java
@@ -1,0 +1,61 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import ch.uzh.ifi.hase.soprafs26.constant.FriendRequestStatus;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "friendRequest")
+public class FriendRequest implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+    @ManyToOne 
+    @JoinColumn(name = "senderId", nullable = false)
+	private User sender;		
+
+    @ManyToOne
+    @JoinColumn(name = "receiverId", nullable = false)
+	private User receiver;
+
+    @Column(nullable = false)
+	private FriendRequestStatus  status; 
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+  
+    public User getSender() {
+        return sender;
+    }
+
+    public void setSender(User sender) {
+        this.sender = sender;
+    }
+
+    public User getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(User receiver) {
+        this.receiver = receiver;
+    }
+    
+    public FriendRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(FriendRequestStatus status) {
+        this.status = status;
+    }
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/User.java
@@ -2,7 +2,9 @@ package ch.uzh.ifi.hase.soprafs26.entity;
 import jakarta.persistence.*;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import java.io.Serializable;
-import java.time.LocalDate;	
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;	
 
 /**
  * Internal User Representation
@@ -48,6 +50,14 @@ public class User implements Serializable {
 
 	@Column(nullable = false)
 	private LocalDate creationDate;
+
+	@ManyToMany
+	@JoinTable(
+	    name = "user_friends",
+	    joinColumns = @JoinColumn(name = "user_id"),
+	    inverseJoinColumns = @JoinColumn(name = "friend_id")
+	)
+	private List<User> friends = new ArrayList<>();	
 
 	public Long getId() {
 		return id;
@@ -110,6 +120,13 @@ public class User implements Serializable {
 	}
 	public void setCreationDate(LocalDate creationDate) {
 		this.creationDate = creationDate;
+	}
+
+	public List<User> getFriends() {
+		return friends;
+	}
+	public void setFriends(List<User> friends) {
+		this.friends = friends;
 	}
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendRequestRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendRequestRepository.java
@@ -1,0 +1,14 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import ch.uzh.ifi.hase.soprafs26.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+
+@Repository("friendRequestRepository")
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+    FriendRequest findBySenderAndReceiverAndStatus(User sender, User receiver, FriendRequestStatus pending);
+	
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendRequestRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendRequestRepository.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +11,6 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 @Repository("friendRequestRepository")
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    FriendRequest findBySenderAndReceiverAndStatus(User sender, User receiver, FriendRequestStatus pending);
+    List<FriendRequest> findByReceiverAndStatus(User receiver, FriendRequestStatus status);
 	
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendRequestRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/FriendRequestRepository.java
@@ -12,5 +12,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 @Repository("friendRequestRepository")
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     List<FriendRequest> findByReceiverAndStatus(User receiver, FriendRequestStatus status);
+
+	FriendRequest findBySenderAndReceiverAndStatus(User sender, User receiver, FriendRequestStatus status);
 	
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/InvitationRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/InvitationRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ch.uzh.ifi.hase.soprafs26.constant.InviteStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Invitation;
+import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 
 @Repository("invitationRepository")
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     List<Invitation> findByReceiverAndStatus(User receiver, InviteStatus status);
+
+    Invitation findByBoardAndReceiverAndStatus(TravelBoard board, User receiver, InviteStatus pending);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FriendRequestGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FriendRequestGetDTO.java
@@ -1,0 +1,58 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.FriendRequestStatus;
+
+public class FriendRequestGetDTO {
+
+    private Long id;
+
+    private Long senderId;
+    
+    private Long receiverId;
+
+    private FriendRequestStatus status;
+
+    private String senderUsername;    
+			
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSenderId() {
+		return senderId;
+	}
+
+	public void setSenderId(Long senderId) {
+		this.senderId = senderId;
+	}
+
+	public Long getReceiverId() {
+		return receiverId;
+	}
+
+	public void setReceiverId(Long receiverId) {
+		this.receiverId = receiverId;
+	}
+
+    public FriendRequestStatus getStatus() {
+		return status;
+	}
+
+    public void setStatus(FriendRequestStatus status) {
+        this.status = status;
+    }
+
+    public String getSenderUsername() {
+        return senderUsername;
+    }
+    
+    public void setSenderUsername(String senderUsername) {
+        this.senderUsername = senderUsername;
+    }
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FriendRequestPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FriendRequestPostDTO.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class FriendRequestPostDTO {
+    
+    private Long receiverId;			
+
+
+	public Long getReceiverId() {
+		return receiverId;
+	}
+
+	public void setReceiverId(Long receiverId) {
+		this.receiverId = receiverId;
+	}
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -3,10 +3,12 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
+import ch.uzh.ifi.hase.soprafs26.entity.FriendRequest;
 import ch.uzh.ifi.hase.soprafs26.entity.Invitation;
 import ch.uzh.ifi.hase.soprafs26.entity.Place;
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.FriendRequestGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.InvitationGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.PlacePostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.TravelBoardGetDTO;
@@ -77,4 +79,12 @@ public interface DTOMapper {
 	@Mapping(source = "latitude", target = "latitude")
 	@Mapping(source = "longitude", target = "longitude")
     Place convertPlacePostDTOtoEntity(PlacePostDTO placePostDTO);
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "sender.id", target = "senderId")
+	@Mapping(source = "receiver.id", target = "receiverId")
+	@Mapping(source = "status", target = "status")
+	@Mapping(source = "sender.username", target = "senderUsername")
+    FriendRequestGetDTO convertEntityToFriendRequestGetDTO(FriendRequest createdFriendRequest);
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
@@ -128,5 +128,30 @@ public class FriendRequestService {
         friendRequestRepository.save(friendRequest);
     }
 
+    public List<User> getFriends(String token) {
+        User user = userRepository.findByToken(token);
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+        }
+
+        return user.getFriends();
+    }
+
+    public void removeFriend(String token, Long friendId) {
+        User user = userRepository.findByToken(token);
+
+        User friend = userRepository.findById(friendId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Friend not found"));
+
+        if (!user.getFriends().contains(friend)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Users are not friends");
+        }
+
+        user.getFriends().remove(friend);
+        friend.getFriends().remove(user);
+
+        userRepository.save(user);
+        userRepository.save(friend);
+    }
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
@@ -1,0 +1,78 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import ch.uzh.ifi.hase.soprafs26.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.FriendRequestRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+
+import java.util.List;
+
+
+
+@Service
+@Transactional
+public class FriendRequestService {
+
+	private final Logger log = LoggerFactory.getLogger(FriendRequestService.class);
+    
+    private final FriendRequestRepository friendRequestRepository;
+    private final UserRepository userRepository;
+
+    public FriendRequestService(@Qualifier("friendRequestRepository") FriendRequestRepository friendRequestRepository, UserRepository userRepository) {
+        this.friendRequestRepository = friendRequestRepository;
+        this.userRepository = userRepository;
+	}
+
+	public List<FriendRequest> getFriendRequests() {
+		return this.friendRequestRepository.findAll();
+	}
+
+	public FriendRequest sendFriendRequest(String token, Long receiverId) {
+        User sender = userRepository.findByToken(token);
+        if (sender == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"); 
+        }
+
+        if (receiverId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Receiver id must not be null");
+        }
+        
+        User receiver = userRepository.findById(receiverId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Receiver not found"));
+
+        if (sender.getId().equals(receiver.getId())){
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "You cannot send a friend request to yourself");
+        }
+
+        FriendRequest accepted1 = friendRequestRepository.findBySenderAndReceiverAndStatus(
+            sender, receiver, FriendRequestStatus.ACCEPTED);
+
+        FriendRequest accepted2 = friendRequestRepository.findBySenderAndReceiverAndStatus(
+            receiver, sender, FriendRequestStatus.ACCEPTED);
+        
+        if (accepted1 != null || accepted2 != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Users are already friends");
+        }
+        
+        FriendRequest newFriendRequest = new FriendRequest();
+        newFriendRequest.setStatus(FriendRequestStatus.PENDING);
+        newFriendRequest.setSender(sender);
+        newFriendRequest.setReceiver(receiver);
+
+        newFriendRequest = friendRequestRepository.save(newFriendRequest);
+
+        log.debug("Created Information for FriendRequest: {}", newFriendRequest);
+        return newFriendRequest;
+	}
+
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
@@ -53,13 +53,7 @@ public class FriendRequestService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "You cannot send a friend request to yourself");
         }
 
-        FriendRequest accepted1 = friendRequestRepository.findBySenderAndReceiverAndStatus(
-            sender, receiver, FriendRequestStatus.ACCEPTED);
-
-        FriendRequest accepted2 = friendRequestRepository.findBySenderAndReceiverAndStatus(
-            receiver, sender, FriendRequestStatus.ACCEPTED);
-        
-        if (accepted1 != null || accepted2 != null) {
+        if (sender.getFriends().contains(receiver) || receiver.getFriends().contains(sender)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Users are already friends");
         }
         
@@ -73,6 +67,66 @@ public class FriendRequestService {
         log.debug("Created Information for FriendRequest: {}", newFriendRequest);
         return newFriendRequest;
 	}
+
+    public List<FriendRequest> getPendingFriendRequests(String token) {
+        User user = userRepository.findByToken(token);
+
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found");
+        }
+
+        return friendRequestRepository.findByReceiverAndStatus(user, FriendRequestStatus.PENDING);
+    }
+
+    public void acceptFriendRequest(Long friendRequestId, String token){
+        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FriendRequest not found"));
+
+        User user = userRepository.findByToken(token);
+
+        if (!friendRequest.getReceiver().getId().equals(user.getId())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized - not your friendRequest");
+        }
+
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "FriendRequest was already answered");
+        }
+
+        User sender = friendRequest.getSender();
+        User receiver = friendRequest.getReceiver();
+
+        if (!sender.getFriends().contains(receiver)) {
+            sender.getFriends().add(receiver);
+        }
+
+        if (!receiver.getFriends().contains(sender)) {
+            receiver.getFriends().add(sender);
+        }
+
+        userRepository.save(sender);
+        userRepository.save(receiver);
+
+        friendRequest.setStatus(FriendRequestStatus.ACCEPTED);
+        friendRequestRepository.save(friendRequest);
+    }
+
+    public void declineFriendRequest(Long friendRequestId, String token){
+        FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "FriendRequest not found"));
+
+        User user = userRepository.findByToken(token);
+
+        if (!friendRequest.getReceiver().getId().equals(user.getId())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized - not your friendRequest");
+        }
+
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "FriendRequest was already answered");
+        }
+
+        friendRequest.setStatus(FriendRequestStatus.DECLINED);
+        friendRequestRepository.save(friendRequest);
+    }
 
 
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/FriendRequestService.java
@@ -56,6 +56,14 @@ public class FriendRequestService {
         if (sender.getFriends().contains(receiver) || receiver.getFriends().contains(sender)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Users are already friends");
         }
+
+        FriendRequest pending1 = friendRequestRepository.findBySenderAndReceiverAndStatus(sender, receiver, FriendRequestStatus.PENDING);
+
+        FriendRequest pending2 = friendRequestRepository.findBySenderAndReceiverAndStatus(receiver, sender, FriendRequestStatus.PENDING);
+
+        if (pending1 != null || pending2 != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "A pending friend request already exists");
+        }
         
         FriendRequest newFriendRequest = new FriendRequest();
         newFriendRequest.setStatus(FriendRequestStatus.PENDING);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/InvitationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/InvitationService.java
@@ -60,6 +60,12 @@ public class InvitationService {
         User receiver = userRepository.findById(receiverId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Receiver not found"));
 
+        Invitation pendingInvitation = invitationRepository.findByBoardAndReceiverAndStatus(board, receiver, InviteStatus.PENDING);
+        
+        if (pendingInvitation != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "A pending invitation for this user and travel board already exists");
+        }
+
         Invitation newInvitation = new Invitation();
         newInvitation.setStatus(InviteStatus.PENDING);
         newInvitation.setBoard(board);


### PR DESCRIPTION
This PR implements the backend functionality for friends:
- create endpoint to send a friend request (POST) #217 
- ensure friend requests cannot be sent to existing friends or yourself #221
- create endpoint to fetch pending friend requests (GET) #236
- create endpoint to accept or decline a friend request (PUT) #237
- create endpoint to fetch user's friend list (GET) #219, #131
- create endpoint to remove a friend (DELETE) #220
- ensure only accepted requests appear in the friend list #238
- ensure duplicate friend requests cannot be sent #241
- ensure duplicate invitations for the same user and travel board cannot be created #242
