### PR TITLE
Tests for Travelboard and Invitation

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/InvitationControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/InvitationControllerTest.java
@@ -1,0 +1,114 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import ch.uzh.ifi.hase.soprafs26.service.InvitationService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import ch.uzh.ifi.hase.soprafs26.entity.Invitation;
+import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.InvitationPostDTO;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+
+@WebMvcTest(InvitationController.class)
+public class InvitationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private InvitationService invitationService;
+
+    @MockitoBean
+    private UserService userService;
+
+    //#262
+    @Test
+    public void getPendingInvitations_validToken_returnsInvitations() throws Exception {
+        String token = "ABC123";
+    
+        User receiver = new User();
+        receiver.setId(1L);
+        receiver.setUsername("receiver");
+    
+        TravelBoard board = new TravelBoard();
+        board.setId(10L);
+        board.setName("Trip");
+    
+        Invitation invitation = new Invitation();
+        invitation.setId(100L);
+        invitation.setReceiver(receiver);
+        invitation.setBoard(board);
+    
+        Mockito.doNothing().when(userService).validateToken(token);
+    
+        Mockito.when(invitationService.getPendingInvitations(token)).thenReturn(List.of(invitation));
+    
+        MockHttpServletRequestBuilder getRequest = get("/invitations")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON);
+    
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk());
+    }
+
+    //#263
+    @Test
+    public void createInvitation_duplicatePendingInvitation_returnsConflict() throws Exception {
+        Long boardId = 1L;
+        String token = "ABC";
+
+        InvitationPostDTO invitationPostDTO = new InvitationPostDTO();
+        invitationPostDTO.setReceiverId(2L);
+
+        Mockito.doNothing().when(userService).validateToken(token);
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.CONFLICT, "A pending invitation for this user and travel board already exists"))
+                .when(invitationService)
+                .createInvitation(boardId, token, 2L);
+
+        MockHttpServletRequestBuilder postRequest = post("/travelboards/{boardId}/invitations", boardId)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(invitationPostDTO));
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isConflict());
+    }
+    
+
+	
+
+	/**
+	 * Helper Method to convert userPostDTO into a JSON string such that the input
+	 * can be processed
+	 * Input will look like this: {"name": "Test User", "username": "testUsername"}
+	 * 
+	 * @param object
+	 * @return string
+	 */
+	private String asJsonString(final Object object) {
+		try {
+			return new ObjectMapper().writeValueAsString(object);
+		} catch (JacksonException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+					String.format("The request body could not be created.%s", e.toString()));
+		}
+	}
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/InvitationControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/InvitationControllerTest.java
@@ -56,7 +56,8 @@ public class InvitationControllerTest {
         invitation.setReceiver(receiver);
         invitation.setBoard(board);
     
-        Mockito.doNothing().when(userService).validateToken(token);
+        User user = new User();
+        Mockito.when(userService.validateToken(token)).thenReturn(user);
     
         Mockito.when(invitationService.getPendingInvitations(token)).thenReturn(List.of(invitation));
     
@@ -77,7 +78,8 @@ public class InvitationControllerTest {
         InvitationPostDTO invitationPostDTO = new InvitationPostDTO();
         invitationPostDTO.setReceiverId(2L);
 
-        Mockito.doNothing().when(userService).validateToken(token);
+        User user = new User();
+        Mockito.when(userService.validateToken(token)).thenReturn(user);
 
         Mockito.doThrow(new ResponseStatusException(HttpStatus.CONFLICT, "A pending invitation for this user and travel board already exists"))
                 .when(invitationService)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardControllerTest.java
@@ -127,7 +127,8 @@ public class TravelBoardControllerTest {
         String token = "ABC";
         String inviteCode = "VALID123";
 
-        Mockito.doNothing().when(userService).validateToken(token);
+        User user = new User();
+        Mockito.when(userService.validateToken(token)).thenReturn(user);
         Mockito.doNothing().when(travelBoardService).joinTravelBoardByInviteCode(token, inviteCode);
 
         MockHttpServletRequestBuilder postRequest = post("/travelboards/join")
@@ -145,7 +146,8 @@ public class TravelBoardControllerTest {
         String token = "ABC";
         String inviteCode = "INVALID123";
 
-        Mockito.doNothing().when(userService).validateToken(token);
+        User user = new User();
+        Mockito.when(userService.validateToken(token)).thenReturn(user);
         Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Invite code is invalid"))
                 .when(travelBoardService)
                 .joinTravelBoardByInviteCode(token, inviteCode);
@@ -164,9 +166,8 @@ public class TravelBoardControllerTest {
     public void joinTravelBoard_missingToken_unauthorized() throws Exception {
         String inviteCode = "BOARD123";
 
-        Mockito.doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized"))
-                .when(userService)
-                .validateToken(null);
+        Mockito.when(userService.validateToken((String) Mockito.isNull()))
+                .thenThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized"));
 
         MockHttpServletRequestBuilder postRequest = post("/travelboards/join")
                 .param("inviteCode", inviteCode)

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TravelBoardControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.server.ResponseStatusException;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -112,6 +113,61 @@ public class TravelBoardControllerTest {
                 .contentType(MediaType.APPLICATION_JSON);
 
         mockMvc.perform(deleteRequest)
+                .andExpect(status().isUnauthorized());
+    }
+
+    //#153
+    @Test
+    public void joinTravelBoard_validCode_ok() throws Exception {
+        String token = "ABC";
+        String inviteCode = "VALID123";
+
+        Mockito.doNothing().when(userService).validateToken(token);
+        Mockito.doNothing().when(travelBoardService).joinTravelBoardByInviteCode(token, inviteCode);
+
+        MockHttpServletRequestBuilder postRequest = post("/travelboards/join")
+                .param("inviteCode", inviteCode)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isOk());
+    }
+
+    //#154
+    @Test
+    public void joinTravelBoard_invalidCode_notFound() throws Exception {
+        String token = "ABC";
+        String inviteCode = "INVALID123";
+
+        Mockito.doNothing().when(userService).validateToken(token);
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Invite code is invalid"))
+                .when(travelBoardService)
+                .joinTravelBoardByInviteCode(token, inviteCode);
+
+        MockHttpServletRequestBuilder postRequest = post("/travelboards/join")
+                .param("inviteCode", inviteCode)
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isNotFound());
+    }
+
+    //#152
+    @Test
+    public void joinTravelBoard_missingToken_unauthorized() throws Exception {
+        String inviteCode = "BOARD123";
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized"))
+                .when(userService)
+                .validateToken(null);
+
+        MockHttpServletRequestBuilder postRequest = post("/travelboards/join")
+                .param("inviteCode", inviteCode)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(postRequest)
                 .andExpect(status().isUnauthorized());
     }
 	

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/InvitationServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/InvitationServiceIntegrationTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.constant.InviteStatus;
 import ch.uzh.ifi.hase.soprafs26.constant.PrivacyLevel;
@@ -163,5 +165,107 @@ public class InvitationServiceIntegrationTest {
         assertEquals(InviteStatus.DECLINED, updatedInvitation.getStatus());
     }
 
+    //#180
+    @Test
+    public void createInvitation_validInput_storesInvitationInDatabase() {
+        // create user: sender/owner
+        User owner = new User();
+        owner.setName("owner");
+        owner.setUsername("owner123");
+        owner.setPassword("pw");
+        owner.setEmail("owner123@test.ch");
+        owner.setCreationDate(LocalDate.now());
+        owner.setStatus(UserStatus.ONLINE);
+        owner.setToken("ownertoken");
+        owner = userRepository.save(owner);
+
+        // create user: receiver
+        User receiver = new User();
+        receiver.setName("receiver");
+        receiver.setUsername("receiver123");
+        receiver.setPassword("pw");
+        receiver.setEmail("receiver123@test.ch");
+        receiver.setCreationDate(LocalDate.now());
+        receiver.setStatus(UserStatus.ONLINE);
+        receiver.setToken("receivertoken");
+        receiver = userRepository.save(receiver);
+
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Paris Trip");
+        board.setOwner(owner);
+        board.setInviteCode("CODE123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+        board = travelBoardRepository.save(board);
+        Long boardId = board.getId();
+    
+        // create invitation
+        Invitation createdInvitation = invitationService.createInvitation(boardId, owner.getToken(), receiver.getId());
+        
+        // assert
+        assertNotNull(createdInvitation.getId());
+        assertEquals(InviteStatus.PENDING, createdInvitation.getStatus());
+        assertEquals(boardId, createdInvitation.getBoard().getId());
+        assertEquals(owner.getId(), createdInvitation.getSender().getId());
+        assertEquals(receiver.getId(), createdInvitation.getReceiver().getId());
+    }
+
+    //#182
+    @Test
+    public void createInvitation_nonOwner_throwsUnauthorized() {
+        // create owner
+        User owner = new User();
+        owner.setName("owner");
+        owner.setUsername("owner123");
+        owner.setPassword("pw");
+        owner.setEmail("owner123@test.ch");
+        owner.setCreationDate(LocalDate.now());
+        owner.setStatus(UserStatus.ONLINE);
+        owner.setToken("ownertoken");
+        owner = userRepository.save(owner);
+
+        // create non-owner (sender)
+        User sender = new User();
+        sender.setName("sender");
+        sender.setUsername("sender123");
+        sender.setPassword("pw");
+        sender.setEmail("sender123@test.ch");
+        sender.setCreationDate(LocalDate.now());
+        sender.setStatus(UserStatus.ONLINE);
+        sender.setToken("sendertoken123");
+        sender = userRepository.save(sender);
+        String senderToken = sender.getToken();
+
+        // create receiver
+        User receiver = new User();
+        receiver.setName("receiver");
+        receiver.setUsername("receiver182");
+        receiver.setPassword("pw");
+        receiver.setEmail("receiver182@test.ch");
+        receiver.setCreationDate(LocalDate.now());
+        receiver.setStatus(UserStatus.ONLINE);
+        receiver.setToken("receiver-token-182");
+        receiver = userRepository.save(receiver);
+        Long receiverId = receiver.getId();
+
+        // create board with owner
+        TravelBoard board = new TravelBoard();
+        board.setName("Owner Only Board");
+        board.setOwner(owner);
+        board.setInviteCode("INV182");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+        board = travelBoardRepository.save(board);
+        Long boardId = board.getId();
+
+        // assert: non-owner tries to create invitation → should fail
+        ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> invitationService.createInvitation(boardId, senderToken, receiverId)
+        );
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+    }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/InvitationServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/InvitationServiceIntegrationTest.java
@@ -55,7 +55,7 @@ public class InvitationServiceIntegrationTest {
         userRepository.deleteAll();
 	}
     
-    //#155
+    //#155,#181
     @Test
     public void acceptInvitation_validPendingInvitation_addsUserAsBoardMember() {
         // create user: sender/owner
@@ -110,7 +110,7 @@ public class InvitationServiceIntegrationTest {
         assertEquals(InviteStatus.ACCEPTED, updatedInvitation.getStatus());
     }
 
-    //#156
+    //#156,#183
     @Test
     public void declineInvitation_validPendingInvitation_doesNotAddUserAsBoardMember() {
         // create user: sender/owner

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/InvitationServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/InvitationServiceIntegrationTest.java
@@ -1,0 +1,167 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import ch.uzh.ifi.hase.soprafs26.constant.InviteStatus;
+import ch.uzh.ifi.hase.soprafs26.constant.PrivacyLevel;
+import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Invitation;
+import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.InvitationRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TravelBoardRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+/**
+ * Test class for the UserResource REST resource.
+ *
+ * @see TravelBoardService
+ */
+@WebAppConfiguration
+@SpringBootTest
+public class InvitationServiceIntegrationTest {
+
+	@Qualifier("userRepository")
+	@Autowired
+	private UserRepository userRepository;
+
+    
+	@Qualifier("travelBoardRepository")
+	@Autowired
+	private TravelBoardRepository travelBoardRepository;
+
+    @Qualifier("invitationRepository")
+    @Autowired
+    private InvitationRepository invitationRepository;
+
+	@Autowired
+	private InvitationService invitationService;
+
+	@BeforeEach
+	public void setup() {
+        invitationRepository.deleteAll();
+		travelBoardRepository.deleteAll();
+        userRepository.deleteAll();
+	}
+    
+    //#155
+    @Test
+    public void acceptInvitation_validPendingInvitation_addsUserAsBoardMember() {
+        // create user: sender/owner
+        User owner = new User();
+        owner.setName("owner");
+        owner.setUsername("owner123");
+        owner.setPassword("pw");
+        owner.setEmail("owner123@test.ch");
+        owner.setCreationDate(LocalDate.now());
+        owner.setStatus(UserStatus.ONLINE);
+        owner.setToken("ownertoken");
+        owner = userRepository.save(owner);
+
+        // create user: receiver
+        User receiver = new User();
+        receiver.setName("receiver");
+        receiver.setUsername("receiver123");
+        receiver.setPassword("pw");
+        receiver.setEmail("receiver123@test.ch");
+        receiver.setCreationDate(LocalDate.now());
+        receiver.setStatus(UserStatus.ONLINE);
+        receiver.setToken("receivertoken");
+        receiver = userRepository.save(receiver);
+
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Paris Trip");
+        board.setOwner(owner);
+        board.setInviteCode("INV123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+        board = travelBoardRepository.save(board);
+        Long boardId = board.getId();
+
+        // create invitation
+        Invitation invitation = new Invitation();
+        invitation.setBoard(board);
+        invitation.setSender(owner);
+        invitation.setReceiver(receiver);
+        invitation.setStatus(InviteStatus.PENDING);
+        invitation = invitationRepository.save(invitation);
+
+        // accept invitation
+        invitationService.acceptInvitation(invitation.getId(), receiver.getToken());
+
+        // assert
+        Invitation updatedInvitation = invitationRepository.findById(invitation.getId()).orElseThrow();
+
+        assertTrue(travelBoardRepository.findByMembersId(receiver.getId())
+                .stream()
+                .anyMatch(b -> b.getId().equals(boardId)));
+        assertEquals(InviteStatus.ACCEPTED, updatedInvitation.getStatus());
+    }
+
+    //#156
+    @Test
+    public void declineInvitation_validPendingInvitation_doesNotAddUserAsBoardMember() {
+        // create user: sender/owner
+        User owner = new User();
+        owner.setName("owner");
+        owner.setUsername("owner123");
+        owner.setPassword("pw");
+        owner.setEmail("owner123@test.ch");
+        owner.setCreationDate(LocalDate.now());
+        owner.setStatus(UserStatus.ONLINE);
+        owner.setToken("ownertoken");
+        owner = userRepository.save(owner);
+
+        // create user: receiver
+        User receiver = new User();
+        receiver.setName("receiver");
+        receiver.setUsername("receiver123");
+        receiver.setPassword("pw");
+        receiver.setEmail("receiver123@test.ch");
+        receiver.setCreationDate(LocalDate.now());
+        receiver.setStatus(UserStatus.ONLINE);
+        receiver.setToken("receivertoken");
+        receiver = userRepository.save(receiver);
+
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Paris Trip");
+        board.setOwner(owner);
+        board.setInviteCode("INV123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+        board = travelBoardRepository.save(board);
+        Long boardId = board.getId();
+
+        // create invitation
+        Invitation invitation = new Invitation();
+        invitation.setBoard(board);
+        invitation.setSender(owner);
+        invitation.setReceiver(receiver);
+        invitation.setStatus(InviteStatus.PENDING);
+        invitation = invitationRepository.save(invitation);
+
+        // decline invitation
+        invitationService.declineInvitation(invitation.getId(), receiver.getToken());
+
+        // assert
+        Invitation updatedInvitation = invitationRepository.findById(invitation.getId()).orElseThrow();
+
+        assertFalse(travelBoardRepository.findByMembersId(receiver.getId())
+                .stream()
+                .anyMatch(b -> b.getId().equals(boardId)));
+        assertEquals(InviteStatus.DECLINED, updatedInvitation.getStatus());
+    }
+
+
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/PreferencesServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/PreferencesServiceIntegrationTest.java
@@ -12,7 +12,9 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.entity.Preferences;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import ch.uzh.ifi.hase.soprafs26.repository.InvitationRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.PreferencesRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TravelBoardRepository;
 
 import java.util.List;
 
@@ -44,6 +46,14 @@ public class PreferencesServiceIntegrationTest {
 	@Autowired
 	private UserRepository userRepository;
 
+    @Qualifier("invitationRepository")
+	@Autowired
+	private InvitationRepository invitationRepository;
+
+	@Qualifier("travelBoardRepository")
+	@Autowired
+	private TravelBoardRepository travelBoardRepository;
+
     @Autowired
 	private PreferencesService preferencesService;
 
@@ -54,6 +64,8 @@ public class PreferencesServiceIntegrationTest {
 
 	@BeforeEach
 	public void setup() {
+        invitationRepository.deleteAll();
+        travelBoardRepository.deleteAll();
         preferencesRepository.deleteAll();
 		userRepository.deleteAll();
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
@@ -185,7 +185,7 @@ public class TravelboardServiceIntegrationTest {
         assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
     }
 
-    //#136 - Duplicate invite Code
+    //#136 - Duplicate invite Code ,#138
     @Test
     public void createTravelBoard_duplicateInviteCode_throwsConflict() {
         // create user
@@ -335,7 +335,7 @@ public class TravelboardServiceIntegrationTest {
         assertNotEquals(inviteCode1, inviteCode2);
     }
 
-    //#153
+    //#153,#117
     @Test
     public void joinTravelBoard_validCode_userAddedToMembers() {
         // create user

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
@@ -119,4 +119,49 @@ public class TravelboardServiceIntegrationTest {
 
         assertEquals("New Name", updated.getName());
     }
+
+    //#153
+    @Test
+    public void joinTravelBoard_validCode_userAddedToMembers() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+
+        // create user to join
+        User joiner = new User();
+        joiner.setName("joiner");
+        joiner.setUsername("joiner123");
+        joiner.setPassword("pw");
+        joiner.setEmail("joiner123@test.ch");
+        joiner.setCreationDate(LocalDate.now());
+        joiner.setStatus(UserStatus.ONLINE);
+        joiner.setToken("token456");
+        joiner = userRepository.save(joiner);
+
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Old Name");
+        board.setOwner(user);
+        board.setInviteCode("ABC123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+
+        board = travelBoardRepository.save(board);
+        Long boardId = board.getId();
+
+        // join add member
+        travelBoardService.joinTravelBoardByInviteCode(joiner.getToken(), "ABC123");
+
+        // assert
+        assertTrue(travelBoardService.getTravelBoardsByUser(joiner.getToken())
+                .stream() // verifies that the board the joiner joined is now included in their travel board list
+                .anyMatch(b -> b.getId().equals(boardId))); // true if any board in that list has the expected ID
+    }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.PrivacyLevel;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.InvitationRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.TravelBoardRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 
@@ -35,11 +36,16 @@ public class TravelboardServiceIntegrationTest {
 	@Autowired
 	private TravelBoardRepository travelBoardRepository;
 
+    @Qualifier("invitationRepository")
+    @Autowired
+    private InvitationRepository invitationRepository;
+
 	@Autowired
 	private TravelBoardService travelBoardService;
 
 	@BeforeEach
 	public void setup() {
+        invitationRepository.deleteAll();
 		travelBoardRepository.deleteAll();
         userRepository.deleteAll();
 	}
@@ -163,5 +169,66 @@ public class TravelboardServiceIntegrationTest {
         assertTrue(travelBoardService.getTravelBoardsByUser(joiner.getToken())
                 .stream() // verifies that the board the joiner joined is now included in their travel board list
                 .anyMatch(b -> b.getId().equals(boardId))); // true if any board in that list has the expected ID
+    }
+
+    //#265
+    @Test
+    public void leaveTravelBoard_validMember_removesOnlyThatUsersMembership() {
+        // create user: owner
+        User owner = new User();
+        owner.setName("owner");
+        owner.setUsername("owner123");
+        owner.setPassword("pw");
+        owner.setEmail("owner123@test.ch");
+        owner.setCreationDate(LocalDate.now());
+        owner.setStatus(UserStatus.ONLINE);
+        owner.setToken("ownertoken");
+        owner = userRepository.save(owner);
+
+        // create user: member1
+        User member1 = new User();
+        member1.setName("member1");
+        member1.setUsername("member123");
+        member1.setPassword("pw");
+        member1.setEmail("member123@test.ch");
+        member1.setCreationDate(LocalDate.now());
+        member1.setStatus(UserStatus.ONLINE);
+        member1.setToken("member-token-1");
+        member1 = userRepository.save(member1);
+
+        // create user: member2
+        User member2 = new User();
+        member2.setName("member2");
+        member2.setUsername("member456");
+        member2.setPassword("pw");
+        member2.setEmail("member456@test.ch");
+        member2.setCreationDate(LocalDate.now());
+        member2.setStatus(UserStatus.ONLINE);
+        member2.setToken("member-token-2");
+        member2 = userRepository.save(member2);
+
+        // create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Group Trip");
+        board.setOwner(owner);
+        board.setInviteCode("LEAVE123");
+        board.setPrivacy(PrivacyLevel.PUBLIC);
+        board.setDateCreated(LocalDate.now());
+        board.getMembers().add(member1);
+        board.getMembers().add(member2);
+        board = travelBoardRepository.save(board);
+        Long boardId = board.getId();
+
+        // member1 leave board
+        travelBoardService.leaveTravelBoard(board.getId(), member1.getToken());
+
+        // assert
+        assertTrue(travelBoardRepository.findById(boardId).isPresent());
+        assertFalse(travelBoardRepository.findByMembersId(member1.getId())
+                .stream()
+                .anyMatch(b -> b.getId().equals(boardId)));
+        assertTrue(travelBoardRepository.findByMembersId(member2.getId())
+                .stream()
+                .anyMatch(b -> b.getId().equals(boardId)));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TravelboardServiceIntegrationTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.server.ResponseStatusException;
+
 import ch.uzh.ifi.hase.soprafs26.constant.PrivacyLevel;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.TravelBoard;
@@ -55,6 +58,169 @@ public class TravelboardServiceIntegrationTest {
         userRepository.deleteAll();
 	}
     
+    //#135
+    @Test
+    public void createTravelBoard_validInput_createsTravelBoard() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+
+        // create travel board input
+        TravelBoard board = new TravelBoard();
+        board.setName("Test Board");
+        board.setInviteCode("CRE123");
+        board.setPrivacy(PrivacyLevel.PRIVATE);
+        board.setDateCreated(LocalDate.now());
+
+        // create board
+        TravelBoard createdBoard = travelBoardService.createTravelBoard(board, user.getToken());
+
+        // assert
+        assertNotNull(createdBoard.getId());
+        assertEquals("Test Board", createdBoard.getName());
+        assertEquals(user.getId(), createdBoard.getOwner().getId());
+        assertEquals("CRE123", createdBoard.getInviteCode());
+        assertEquals(PrivacyLevel.PRIVATE, createdBoard.getPrivacy());
+
+        TravelBoard storedBoard = travelBoardRepository.findById(createdBoard.getId()).orElseThrow();
+        assertEquals("Test Board", storedBoard.getName());
+    }
+
+    //#136 - Missing name
+    @Test
+    public void createTravelBoard_missingName_throwsBadRequest() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+        String userToken = user.getToken();
+
+        //create board
+        TravelBoard board = new TravelBoard();
+        board.setName(null);
+        board.setPrivacy(PrivacyLevel.PRIVATE);
+        board.setInviteCode("CODE123");
+
+        // assert
+        ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> travelBoardService.createTravelBoard(board, userToken)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    //#136 - Missing privacy
+    @Test
+    public void createTravelBoard_missingPrivacy_throwsBadRequest() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+        String userToken = user.getToken();
+
+        //create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Trip");
+        board.setPrivacy(null);
+        board.setInviteCode("CODE123");
+
+        // assert
+        ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> travelBoardService.createTravelBoard(board, userToken)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    //#136 - Invalid dates
+    @Test
+    public void createTravelBoard_startDateAfterEndDate_throwsBadRequest() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+        String userToken = user.getToken();
+
+        //create board
+        TravelBoard board = new TravelBoard();
+        board.setName("Trip");
+        board.setPrivacy(PrivacyLevel.PRIVATE);
+        board.setInviteCode("CODE123");
+        board.setStartDate(LocalDate.of(2026, 6, 10));
+        board.setEndDate(LocalDate.of(2026, 6, 5));
+
+        // assert
+        ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> travelBoardService.createTravelBoard(board, userToken)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    //#136 - Duplicate invite Code
+    @Test
+    public void createTravelBoard_duplicateInviteCode_throwsConflict() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+        String userToken = user.getToken();
+
+        //create first board
+        TravelBoard firstBoard = new TravelBoard();
+        firstBoard.setName("First Trip");
+        firstBoard.setPrivacy(PrivacyLevel.PRIVATE);
+        firstBoard.setInviteCode("DUP123");
+        firstBoard = travelBoardService.createTravelBoard(firstBoard, userToken);
+
+        //create second board with the same invite Code
+        TravelBoard secondBoard = new TravelBoard();
+        secondBoard.setName("Second Trip");
+        secondBoard.setPrivacy(PrivacyLevel.PRIVATE);
+        secondBoard.setInviteCode("DUP123");
+
+        ResponseStatusException exception = assertThrows(
+            ResponseStatusException.class,
+            () -> travelBoardService.createTravelBoard(secondBoard, userToken)
+        );
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+    }
+
     //#118
     @Test
     public void deleteTravelBoard_removesBoardFromDatabase() {
@@ -129,6 +295,44 @@ public class TravelboardServiceIntegrationTest {
         TravelBoard updated = travelBoardRepository.findById(boardId).orElseThrow();
 
         assertEquals("New Name", updated.getName());
+    }
+
+    //#139
+    @Test
+    public void getInviteCode_returnsCorrectCodeForEachBoard() {
+        // create user
+        User user = new User();
+        user.setName("owner");
+        user.setUsername("owner123");
+        user.setPassword("pw");
+        user.setEmail("owner123@test.ch");
+        user.setCreationDate(LocalDate.now());
+        user.setStatus(UserStatus.ONLINE);
+        user.setToken("token123");
+        user = userRepository.save(user);
+
+        // create first board
+        TravelBoard board1 = new TravelBoard();
+        board1.setName("First Trip");
+        board1.setPrivacy(PrivacyLevel.PRIVATE);
+        board1.setInviteCode("1CODE123");
+        board1 = travelBoardService.createTravelBoard(board1, user.getToken());
+
+        // create second board
+        TravelBoard board2 = new TravelBoard();
+        board2.setName("SecondTrip");
+        board2.setPrivacy(PrivacyLevel.PUBLIC);
+        board2.setInviteCode("2CODE123");
+        board2 = travelBoardService.createTravelBoard(board2, user.getToken());
+
+        // get invite codes
+        String inviteCode1 = travelBoardService.getInviteCode(board1.getId());
+        String inviteCode2 = travelBoardService.getInviteCode(board2.getId());
+
+        // assert
+        assertEquals("1CODE123", inviteCode1);
+        assertEquals("2CODE123", inviteCode2);
+        assertNotEquals(inviteCode1, inviteCode2);
     }
 
     //#153

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -11,7 +11,9 @@ import org.springframework.web.server.ResponseStatusException;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.InvitationRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.PreferencesRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.TravelBoardRepository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,11 +43,21 @@ public class UserServiceIntegrationTest {
 	@Autowired
 	private PreferencesRepository preferencesRepository;
 
+	@Qualifier("invitationRepository")
+	@Autowired
+	private InvitationRepository invitationRepository;
+
+	@Qualifier("travelBoardRepository")
+	@Autowired
+	private TravelBoardRepository travelBoardRepository;
+
 	@Autowired
 	private UserService userService;
 
 	@BeforeEach
 	public void setup() {
+		invitationRepository.deleteAll();
+		travelBoardRepository.deleteAll();
 		preferencesRepository.deleteAll();
 		userRepository.deleteAll();
 	}


### PR DESCRIPTION
This PR includes:

Only logged-in users can join a board (#152)
Users are added as members only with a valid invite code (#153, #117)
Invalid invite codes return an error (#154)
Leaving a board removes only the user’s membership (#265)

Accepting a pending invitation adds the user as a board member (#155, #181)
Declining an invitation does not add the user (#156, #183)
Pending invitations for the current user are returned correctly (#262)
Duplicate pending invitations return a conflict (#263)
Invitations are stored in the database after sending (#180)
Only the board owner can send invitations (#182)

Valid board creation succeeds (#135)
Invalid input (missing fields, invalid dates, duplicate invite code) returns errors (#136, #138)
Invite codes correctly map to boards (#139)